### PR TITLE
Enable required DHCP option in systemd-networkd

### DIFF
--- a/patches/etc/systemd/network/eth0.network
+++ b/patches/etc/systemd/network/eth0.network
@@ -2,6 +2,7 @@
 Name=eth0
 
 [Network]
+DHCP=yes
 DNS=10.1.31.38
 DNS=10.1.31.39
 Domains=scaleway.com


### PR DESCRIPTION
Under systemd 228 the DHCP option (or another similar) seems to be needed for systemd-networkd to startup and not halt the rest of the startup as reported in #25

I'm not able to allocate a fresh node to test this on but I have tested on my current allocated node, which boots fine with systemd 228 after adding this fix to the .network file.

